### PR TITLE
Make compatible with OCI images

### DIFF
--- a/dreg_client/client.py
+++ b/dreg_client/client.py
@@ -12,7 +12,7 @@ from .manifest import (
     parse_image_config_blob_response,
     parse_manifest_response,
 )
-from .schemas import schema_2, schema_2_list
+from .schemas import schema_2, schema_2_list, schema_oci, schema_oci_list
 
 
 if TYPE_CHECKING:
@@ -120,7 +120,7 @@ class Client:
 
     def check_manifest(self, name: str, reference: str) -> Optional[str]:
         headers: HEADERS = {
-            "Accept": ",".join((schema_2, schema_2_list)),
+            "Accept": ",".join((schema_2, schema_2_list, schema_oci, schema_oci_list)),
         }
         try:
             response = self._head(
@@ -135,7 +135,7 @@ class Client:
 
     def get_manifest(self, name: str, reference: str) -> ManifestParseOutput:
         headers: HEADERS = {
-            "Accept": ",".join((schema_2, schema_2_list)),
+            "Accept": ",".join((schema_2, schema_2_list, schema_oci, schema_oci_list)),
         }
         response = self._get(f"{name}/manifests/{reference}", scope_repo(name), headers=headers)
 

--- a/dreg_client/manifest.py
+++ b/dreg_client/manifest.py
@@ -317,6 +317,12 @@ def parse_manifest_response(response: Response) -> ManifestParseOutput:
         raise UnusableManifestPayloadError(response, data, "Unknown schema version in payload.")
 
     if content_type in (schema_2, schema_oci):
+        # OCI image does not set mediaType in data
+        if content_type == schema_2 and data.get("mediaType") != content_type:
+            raise UnusableManifestPayloadError(
+                response, data, "Mismatched media type between headers and payload."
+            )
+
         config_data = data["config"]
         layers_data = data["layers"]
 
@@ -345,6 +351,12 @@ def parse_manifest_response(response: Response) -> ManifestParseOutput:
         )
 
     if content_type in (schema_2_list, schema_oci_list):
+        # OCI image does not set mediaType in data
+        if content_type == schema_2_list and data.get("mediaType") != content_type:
+            raise UnusableManifestPayloadError(
+                response, data, "Mismatched media type between headers and payload."
+            )
+
         manifests_data = data["manifests"]
 
         manifests: Set[ManifestRef] = set()

--- a/dreg_client/manifest.py
+++ b/dreg_client/manifest.py
@@ -20,6 +20,8 @@ from .schemas import (
     legacy_manifest_content_types,
     schema_2,
     schema_2_list,
+    schema_oci,
+    schema_oci_list,
 )
 
 
@@ -314,12 +316,7 @@ def parse_manifest_response(response: Response) -> ManifestParseOutput:
     if data.get("schemaVersion") != 2:
         raise UnusableManifestPayloadError(response, data, "Unknown schema version in payload.")
 
-    if content_type == schema_2:
-        if data.get("mediaType") != content_type:
-            raise UnusableManifestPayloadError(
-                response, data, "Mismatched media type between headers and payload."
-            )
-
+    if content_type in (schema_2, schema_oci):
         config_data = data["config"]
         layers_data = data["layers"]
 
@@ -347,12 +344,7 @@ def parse_manifest_response(response: Response) -> ManifestParseOutput:
             layers=tuple(layers),
         )
 
-    if content_type == schema_2_list:
-        if data.get("mediaType") != content_type:
-            raise UnusableManifestPayloadError(
-                response, data, "Mismatched media type between headers and payload."
-            )
-
+    if content_type in (schema_2_list, schema_oci_list):
         manifests_data = data["manifests"]
 
         manifests: Set[ManifestRef] = set()

--- a/dreg_client/schemas.py
+++ b/dreg_client/schemas.py
@@ -1,9 +1,13 @@
 BASE_CONTENT_TYPE = "application/vnd.docker.distribution.manifest"
+OCI_CONTENT_TYPE = "application/vnd.oci.image.manifest"
 
 schema_1 = BASE_CONTENT_TYPE + ".v1+json"
 schema_1_signed = BASE_CONTENT_TYPE + ".v1+prettyjws"
 schema_2 = BASE_CONTENT_TYPE + ".v2+json"
 schema_2_list = BASE_CONTENT_TYPE + ".list.v2+json"
+schema_oci = OCI_CONTENT_TYPE + ".v1+json"
+schema_oci_list = OCI_CONTENT_TYPE + ".list.v1+json"
+
 
 legacy_manifest_content_types = frozenset(
     {
@@ -14,6 +18,8 @@ legacy_manifest_content_types = frozenset(
 known_manifest_content_types = legacy_manifest_content_types | {
     schema_2,
     schema_2_list,
+    schema_oci,
+    schema_oci_list,
 }
 
 
@@ -22,6 +28,8 @@ __all__ = (
     "schema_1_signed",
     "schema_2",
     "schema_2_list",
+    "schema_oci",
+    "schema_oci_list",
     "legacy_manifest_content_types",
     "known_manifest_content_types",
 )


### PR DESCRIPTION
If you use alternatives to docker like [buildah](https://buildah.io/) to build and push images, you will see a different schema in your registry.

The structure is almost identical, but the data lacks an attribute for `mediaType`. That's why I saw no possibility to keep those checks in place.